### PR TITLE
Fix test warnings on Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
   - "3.6"
   - "3.7"
 env:
-  - NETWORKX_VERSION=1
-  - NETWORKX_VERSION=2
+  - NETWORKX_VERSION='1.*'
+  - NETWORKX_VERSION='2.*'
 install:
   - pip install networkx==$NETWORKX_VERSION
   - pip install .
@@ -22,7 +22,7 @@ deploy:
       secure: M3uAhXVdyyM69DoeiGdqIk+epOKr60NN1hAtncPJoo1nP3tZTT7zDiocemXszmCxyNhlAfD5xREVaQouwFbLxv1BleaxLUCyw81+VpAy4JW+4qTHrbWYedXXMYp+tOpRa3q4q6nLFTRVF6Nx6Yx/88UibiYj/soI2CcM7xekMCfs3LwSJwVHjXD++NvUFw913uqlRau2MZYnZDiVFUbkC5OJ+ulef7yG+HvmhJ/snL0nJY12ecThqV/ZWeoiAp1TFQKC38Z/k01SXHKTXJ6upknWWQQK9csisQ9r+E4u4XibMMPKV0PHKl3mP+vFTyAU2CDmXKvLzIGFdPAB/mp4KrEu8UB8bWJ07RdbPkohTHFv594qBUEA1AITnHQQp+KzFdMNQaK6Em98kdEThSxUrNTf9eNXWbEhtGhITGbYVtRXZPUfl3nYaM8H0iBUtYfC/ZrP+HDhZBMo6c00yvZDQQI1TwZOO2dooDsnwdd/HkqzhVKxqDKvQLhZnc9bwFhQvnxjcX2W2CwZvQqmw1ejKGtnp1/em9AYCn9PcoiiTWs1Su7LV5VeL09X3p1VAExCemrGSoYuEBZaPAMzUs1AqatbTfAry8LJ5Aab4PLx9eDESf16/vdo7WWNFuJMp+iGDf4jwFQZcV/Dnr0zXbMupYogaT/pi0KI0wT6+UZpQ0M=
     on:
       python: "3.7"
-      condition: $NETWORKX_VERSION = 2
+      condition: $NETWORKX_VERSION = '2.*'
       repo: dhimmel/obonet
       tags: true
       distributions: sdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
   - "3.6"
   - "3.7"
 env:
-  - NETWORKX_VERSION='1.*'
-  - NETWORKX_VERSION='2.*'
+  - NETWORKX_VERSION=1.*
+  - NETWORKX_VERSION=2.*
 install:
   - pip install networkx==$NETWORKX_VERSION
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
   - "3.6"
   - "3.7"
 env:
-  - NETWORKX_VERSION=1.11
-  - NETWORKX_VERSION=2.0
+  - NETWORKX_VERSION=1
+  - NETWORKX_VERSION=2
 install:
   - pip install networkx==$NETWORKX_VERSION
   - pip install .
@@ -22,7 +22,7 @@ deploy:
       secure: M3uAhXVdyyM69DoeiGdqIk+epOKr60NN1hAtncPJoo1nP3tZTT7zDiocemXszmCxyNhlAfD5xREVaQouwFbLxv1BleaxLUCyw81+VpAy4JW+4qTHrbWYedXXMYp+tOpRa3q4q6nLFTRVF6Nx6Yx/88UibiYj/soI2CcM7xekMCfs3LwSJwVHjXD++NvUFw913uqlRau2MZYnZDiVFUbkC5OJ+ulef7yG+HvmhJ/snL0nJY12ecThqV/ZWeoiAp1TFQKC38Z/k01SXHKTXJ6upknWWQQK9csisQ9r+E4u4XibMMPKV0PHKl3mP+vFTyAU2CDmXKvLzIGFdPAB/mp4KrEu8UB8bWJ07RdbPkohTHFv594qBUEA1AITnHQQp+KzFdMNQaK6Em98kdEThSxUrNTf9eNXWbEhtGhITGbYVtRXZPUfl3nYaM8H0iBUtYfC/ZrP+HDhZBMo6c00yvZDQQI1TwZOO2dooDsnwdd/HkqzhVKxqDKvQLhZnc9bwFhQvnxjcX2W2CwZvQqmw1ejKGtnp1/em9AYCn9PcoiiTWs1Su7LV5VeL09X3p1VAExCemrGSoYuEBZaPAMzUs1AqatbTfAry8LJ5Aab4PLx9eDESf16/vdo7WWNFuJMp+iGDf4jwFQZcV/Dnr0zXbMupYogaT/pi0KI0wT6+UZpQ0M=
     on:
       python: "3.7"
-      condition: $NETWORKX_VERSION = 2.0
+      condition: $NETWORKX_VERSION = 2
       repo: dhimmel/obonet
       tags: true
       distributions: sdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ deploy:
       secure: M3uAhXVdyyM69DoeiGdqIk+epOKr60NN1hAtncPJoo1nP3tZTT7zDiocemXszmCxyNhlAfD5xREVaQouwFbLxv1BleaxLUCyw81+VpAy4JW+4qTHrbWYedXXMYp+tOpRa3q4q6nLFTRVF6Nx6Yx/88UibiYj/soI2CcM7xekMCfs3LwSJwVHjXD++NvUFw913uqlRau2MZYnZDiVFUbkC5OJ+ulef7yG+HvmhJ/snL0nJY12ecThqV/ZWeoiAp1TFQKC38Z/k01SXHKTXJ6upknWWQQK9csisQ9r+E4u4XibMMPKV0PHKl3mP+vFTyAU2CDmXKvLzIGFdPAB/mp4KrEu8UB8bWJ07RdbPkohTHFv594qBUEA1AITnHQQp+KzFdMNQaK6Em98kdEThSxUrNTf9eNXWbEhtGhITGbYVtRXZPUfl3nYaM8H0iBUtYfC/ZrP+HDhZBMo6c00yvZDQQI1TwZOO2dooDsnwdd/HkqzhVKxqDKvQLhZnc9bwFhQvnxjcX2W2CwZvQqmw1ejKGtnp1/em9AYCn9PcoiiTWs1Su7LV5VeL09X3p1VAExCemrGSoYuEBZaPAMzUs1AqatbTfAry8LJ5Aab4PLx9eDESf16/vdo7WWNFuJMp+iGDf4jwFQZcV/Dnr0zXbMupYogaT/pi0KI0wT6+UZpQ0M=
     on:
       python: "3.7"
-      condition: $NETWORKX_VERSION = '2.*'
+      condition: $NETWORKX_VERSION = 2.*
       repo: dhimmel/obonet
       tags: true
       distributions: sdist bdist_wheel

--- a/tests/test_obo_reading.py
+++ b/tests/test_obo_reading.py
@@ -114,7 +114,7 @@ def test_parse_tag_line_with_tag_value_trailing_modifier_and_comment():
 
 
 def test_parse_tag_line_backslashed_exclamation():
-    line = 'synonym: not a real example \!\n'
+    line = 'synonym: not a real example \\!\n'
     tag, value, trailing_modifier, comment = parse_tag_line(line)
     assert tag == 'synonym'
-    assert value == 'not a real example \!'
+    assert value == r'not a real example \!'


### PR DESCRIPTION
https://travis-ci.org/dhimmel/obonet/jobs/496245613#L284

```
=============================== warnings summary ===============================
tests/test_obo_reading.py:117
  /home/travis/build/dhimmel/obonet/tests/test_obo_reading.py:117: DeprecationWarning: invalid escape sequence \!
    line = 'synonym: not a real example \!\n'
tests/test_obo_reading.py:120
  /home/travis/build/dhimmel/obonet/tests/test_obo_reading.py:120: DeprecationWarning: invalid escape sequence \!
    assert value == 'not a real example \!'
/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/networkx/classes/graph.py:23
  /home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/networkx/classes/graph.py:23: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Mapping
/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/networkx/classes/reportviews.py:95
  /home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/networkx/classes/reportviews.py:95: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Mapping, Set, Iterable
  /home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/networkx/classes/reportviews.py:95: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Mapping, Set, Iterable
-- Docs: https://docs.pytest.org/en/latest/warnings.html
```