### PR TITLE
Added ability to include nodes marked as obsolete

### DIFF
--- a/obonet/read.py
+++ b/obonet/read.py
@@ -35,8 +35,8 @@ def read_obo(path_or_file, ignore_obsolete=True):
     edge_tuples = list()
 
     for term in terms:
-        is_obsolete = ignore_obsolete and term.get('is_obsolete', 'false') == 'true'
-        if is_obsolete:
+        is_obsolete = term.get('is_obsolete', 'false') == 'true'
+        if ignore_obsolete and is_obsolete:
             continue
         term_id = term.pop('id')
         graph.add_node(term_id, **term)

--- a/obonet/read.py
+++ b/obonet/read.py
@@ -6,7 +6,7 @@ import networkx
 from .io import open_read_file
 
 
-def read_obo(path_or_file):
+def read_obo(path_or_file, ignore_obsolete=True):
     """
     Return a networkx.MultiDiGraph of the ontology serialized by the
     specified path or file.
@@ -19,6 +19,9 @@ def read_obo(path_or_file):
     path_or_file : str or file
         Path, URL, or open file object. If path or URL, compression is
         inferred from the file extension.
+    ignore_obsolete : boolean
+        When true (default), terms that are marked 'is_obsolete' will
+        not be added to the graph. 
     """
     obo_file = open_read_file(path_or_file)
     typedefs, terms, instances, header = get_sections(obo_file)
@@ -32,7 +35,7 @@ def read_obo(path_or_file):
     edge_tuples = list()
 
     for term in terms:
-        is_obsolete = term.get('is_obsolete', 'false') == 'true'
+        is_obsolete = ignore_obsolete and term.get('is_obsolete', 'false') == 'true'
         if is_obsolete:
             continue
         term_id = term.pop('id')

--- a/tests/data/brenda-subset.obo
+++ b/tests/data/brenda-subset.obo
@@ -13,6 +13,12 @@ id: BTO:0000000
 name: tissues, cell types and enzyme sources
 def: "A structured controlled vocabulary for the source of an enzyme. It comprises terms of tissues, cell lines, cell types and cell cultures from uni- and multicellular organisms." [curators:mgr]
 
+[Term]
+id: BTO:0000311
+name: culture filtrate
+comment: Added as synonym to culture fluid.
+is_obsolete: true
+
 [Typedef]
 id: develops_from
 name: derives from/develops from
@@ -28,3 +34,4 @@ name: part of
 [Typedef]
 id: related_to
 name: related to
+

--- a/tests/test_obo_reading.py
+++ b/tests/test_obo_reading.py
@@ -8,7 +8,6 @@ from obonet.read import parse_tag_line
 
 directory = os.path.dirname(os.path.abspath(__file__))
 
-
 def test_read_taxrank_file():
     """
     Test reading the taxrank ontology OBO file.
@@ -17,9 +16,8 @@ def test_read_taxrank_file():
     with open(path, 'rt') as read_file:
         taxrank = obonet.read_obo(read_file)
     assert len(taxrank) == 61
-    # It looks like networkx has changed the name of the node variable to nodes -- EST 2020-09-25
-    assert taxrank.nodes['TAXRANK:0000001']['name'] == 'phylum'
-    assert 'NCBITaxon:kingdom' in taxrank.nodes['TAXRANK:0000017']['xref']
+    assert taxrank.node['TAXRANK:0000001']['name'] == 'phylum'
+    assert 'NCBITaxon:kingdom' in taxrank.node['TAXRANK:0000017']['xref']
 
 
 @pytest.mark.parametrize('extension', ['', '.gz', '.bz2', '.xz'])
@@ -121,13 +119,15 @@ def test_parse_tag_line_backslashed_exclamation():
     assert value == r'not a real example \!'
 
 def test_ignore_obsolete_nodes():
-    hpo = obonet.read_obo("http://purl.obolibrary.org/obo/hp.obo")
-    nodes = hpo.nodes(data=True)
-    assert "HP:0005549" not in nodes
+    path = os.path.join(directory, 'data', 'brenda-subset.obo')
+    brenda = obonet.read_obo(path)
+    nodes = brenda.nodes(data=True)
+    assert "BTO:0000311" not in nodes
 
 def test_presence_of_obsolete_nodes():
-    hpo = obonet.read_obo("http://purl.obolibrary.org/obo/hp.obo", ignore_obsolete=False)
-    nodes = hpo.nodes(data=True)
-    assert "HP:0005549" in nodes
-    node = nodes['HP:0005549']
+    path = os.path.join(directory, 'data', 'brenda-subset.obo')
+    brenda = obonet.read_obo(path, ignore_obsolete=False)
+    nodes = brenda.nodes(data=True)
+    assert "BTO:0000311" in nodes
+    node = nodes['BTO:0000311']
     assert node['is_obsolete'] == 'true'

--- a/tests/test_obo_reading.py
+++ b/tests/test_obo_reading.py
@@ -17,8 +17,9 @@ def test_read_taxrank_file():
     with open(path, 'rt') as read_file:
         taxrank = obonet.read_obo(read_file)
     assert len(taxrank) == 61
-    assert taxrank.node['TAXRANK:0000001']['name'] == 'phylum'
-    assert 'NCBITaxon:kingdom' in taxrank.node['TAXRANK:0000017']['xref']
+    # It looks like networkx has changed the name of the node variable to nodes -- EST 2020-09-25
+    assert taxrank.nodes['TAXRANK:0000001']['name'] == 'phylum'
+    assert 'NCBITaxon:kingdom' in taxrank.nodes['TAXRANK:0000017']['xref']
 
 
 @pytest.mark.parametrize('extension', ['', '.gz', '.bz2', '.xz'])
@@ -118,3 +119,15 @@ def test_parse_tag_line_backslashed_exclamation():
     tag, value, trailing_modifier, comment = parse_tag_line(line)
     assert tag == 'synonym'
     assert value == r'not a real example \!'
+
+def test_ignore_obsolete_nodes():
+    hpo = obonet.read_obo("http://purl.obolibrary.org/obo/hp.obo")
+    nodes = hpo.nodes(data=True)
+    assert "HP:0005549" not in nodes
+
+def test_presence_of_obsolete_nodes():
+    hpo = obonet.read_obo("http://purl.obolibrary.org/obo/hp.obo", ignore_obsolete=False)
+    nodes = hpo.nodes(data=True)
+    assert "HP:0005549" in nodes
+    node = nodes['HP:0005549']
+    assert node['is_obsolete'] == 'true'

--- a/tests/test_obo_reading.py
+++ b/tests/test_obo_reading.py
@@ -12,12 +12,13 @@ def test_read_taxrank_file():
     """
     Test reading the taxrank ontology OBO file.
     """
+    pytest.importorskip("networkx", minversion="2.0")
     path = os.path.join(directory, 'data', 'taxrank.obo')
     with open(path, 'rt') as read_file:
         taxrank = obonet.read_obo(read_file)
     assert len(taxrank) == 61
-    assert taxrank.node['TAXRANK:0000001']['name'] == 'phylum'
-    assert 'NCBITaxon:kingdom' in taxrank.node['TAXRANK:0000017']['xref']
+    assert taxrank.nodes['TAXRANK:0000001']['name'] == 'phylum'
+    assert 'NCBITaxon:kingdom' in taxrank.nodes['TAXRANK:0000017']['xref']
 
 
 @pytest.mark.parametrize('extension', ['', '.gz', '.bz2', '.xz'])
@@ -119,12 +120,14 @@ def test_parse_tag_line_backslashed_exclamation():
     assert value == r'not a real example \!'
 
 def test_ignore_obsolete_nodes():
+    """Quick verification that the change doesn't break anything"""
     path = os.path.join(directory, 'data', 'brenda-subset.obo')
     brenda = obonet.read_obo(path)
     nodes = brenda.nodes(data=True)
     assert "BTO:0000311" not in nodes
 
 def test_presence_of_obsolete_nodes():
+    """Test that we did, indeed, capture those obsolete entries"""
     pytest.importorskip("networkx", minversion="2.0")
     path = os.path.join(directory, 'data', 'brenda-subset.obo')
     brenda = obonet.read_obo(path, ignore_obsolete=False)

--- a/tests/test_obo_reading.py
+++ b/tests/test_obo_reading.py
@@ -125,6 +125,7 @@ def test_ignore_obsolete_nodes():
     assert "BTO:0000311" not in nodes
 
 def test_presence_of_obsolete_nodes():
+    pytest.importorskip("networkx", minversion="2.0")
     path = os.path.join(directory, 'data', 'brenda-subset.obo')
     brenda = obonet.read_obo(path, ignore_obsolete=False)
     nodes = brenda.nodes(data=True)


### PR DESCRIPTION
Added parameter to the read_obo function to permit users to keep obsolete nodes in their graphs. Default is such that it shouldn't break any pre-existing client calls. 