### PR TITLE
Handle case where no header is found

### DIFF
--- a/obonet/read.py
+++ b/obonet/read.py
@@ -68,6 +68,7 @@ def get_sections(lines):
     dictionaries and `header` is a dictionary.
     """
     typedefs, terms, instances = [], [], []
+    header = None
     groups = itertools.groupby(lines, lambda line: line.strip() == "")
     for is_blank, stanza_lines in groups:
         if is_blank:
@@ -86,6 +87,9 @@ def get_sections(lines):
         else:
             stanza_lines = [stanza_type_line] + stanza_lines
             header = parse_stanza(stanza_lines, header_tag_singularity)
+    if header is None:
+        logger.warning("got no header information")
+        header = {}
     return typedefs, terms, instances, header
 
 


### PR DESCRIPTION
The header value is only assigned within a conditional, so when parsing sketchy ontologies that don't have properly written headers, it ends up giving an exception like `cannot access local variable 'header' where it is not associated with a value`. This PR changes that to send a warning instead and let the program move on. Alternatively, this could be a place to issue a proper exception