### PR TITLE
Get version without deprecation warnings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
         - windows-latest
         - macOS-latest
         python-version:
-        - "3.7"
+        - "3.8"
         - "3.11"
         networkx-version:
         - "1.*"

--- a/obonet/__init__.py
+++ b/obonet/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import sys
 
 from .read import read_obo
 
@@ -9,21 +8,12 @@ __all__ = [
 
 
 def _get_version() -> str | None:
-    # https://github.com/pypa/setuptools_scm#retrieving-package-version-at-runtime
-    if sys.version_info >= (3, 8):
-        from importlib.metadata import PackageNotFoundError, version
+    from importlib.metadata import PackageNotFoundError, version
 
-        try:
-            return version("obonet")
-        except PackageNotFoundError:
-            return None
-    else:
-        from pkg_resources import DistributionNotFound, get_distribution
-
-        try:
-            return str(get_distribution("obonet").version)
-        except DistributionNotFound:
-            return None
+    try:
+        return version("obonet")
+    except PackageNotFoundError:
+        return None
 
 
 __version__ = _get_version()

--- a/obonet/__init__.py
+++ b/obonet/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import sys
 
 from .read import read_obo
 
@@ -9,12 +10,20 @@ __all__ = [
 
 def _get_version() -> str | None:
     # https://github.com/pypa/setuptools_scm#retrieving-package-version-at-runtime
-    from pkg_resources import DistributionNotFound, get_distribution
+    if sys.version_info >= (3, 8):
+        from importlib.metadata import PackageNotFoundError, version
 
-    try:
-        return str(get_distribution("obonet").version)
-    except DistributionNotFound:
-        return None
+        try:
+            return version("obonet")
+        except PackageNotFoundError:
+            return None
+    else:
+        from pkg_resources import DistributionNotFound, get_distribution
+
+        try:
+            return str(get_distribution("obonet").version)
+        except DistributionNotFound:
+            return None
 
 
 __version__ = _get_version()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ keywords = [
     "parser",
     "network",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = ["networkx"]
 dynamic = ["version"]
 
@@ -54,7 +54,7 @@ include-package-data = true
 license-files = ["LICENSE.md"]
 
 [tool.ruff]
-target-version = "py37"
+target-version = "py38"
 ignore = [
     "E501",  # line-too-long (black should handle)
 ]


### PR DESCRIPTION
The line ```from pkg_resources import DistributionNotFound, get_distribution``` produces deprecation warnings (see https://setuptools.pypa.io/en/latest/pkg_resources.html). This PR implements a variant for Python 3.8+ that avoids these deprecations.