### PR TITLE
Make parsing regexp more robust

### DIFF
--- a/obonet/read.py
+++ b/obonet/read.py
@@ -105,7 +105,24 @@ def get_sections(
 
 # regular expression to parse key-value pair lines.
 tag_line_pattern = re.compile(
-    r"^(?P<tag>.+?): *(?P<value>.+?) ?(?P<trailing_modifier>(?<!\\)\{.*?(?<!\\)\})? ?(?P<comment>(?<!\\)!.*?)?$"
+    r"""^
+    (?P<tag>.+?):\s*                    # tag and separator
+    (?P<value>                          # value group
+        (?:                             # non-capturing group for value content
+            [^!{]                       # any char except ! or {
+            |\\[!{]}                    # or an escaped !, { or }
+            |{[^{}]*}                   # or nested group like {stuff} (not counted as modifier)
+        )+?
+    )\s*                                # optional whitespace
+    (?P<trailing_modifier>              # optional trailing modifier
+        (?<!\\)\{[^{}]*\}
+    )?                                  # optional
+    \s*                                 # optional whitespace
+    (?P<comment>                        # optional comment
+        (?<!\\)!.*                      # starts with unescaped !
+    )?$
+    """,
+    re.VERBOSE,
 )
 
 

--- a/obonet/read.py
+++ b/obonet/read.py
@@ -123,6 +123,7 @@ tag_line_pattern = re.compile(
     re.VERBOSE,
 )
 
+
 def parse_tag_line(line: str) -> tuple[str, str | None, str | None, str | None]:
     """
     Take a line representing a single tag-value pair and parse

--- a/obonet/read.py
+++ b/obonet/read.py
@@ -106,25 +106,22 @@ def get_sections(
 # regular expression to parse key-value pair lines.
 tag_line_pattern = re.compile(
     r"""^
-    (?P<tag>.+?):\s*                    # tag and separator
-    (?P<value>                          # value group
-        (?:                             # non-capturing group for value content
-            [^!{]                       # any char except ! or {
-            |\\[!{]}                    # or an escaped !, { or }
-            |{[^{}]*}                   # or nested group like {stuff} (not counted as modifier)
-        )+?
-    )\s*                                # optional whitespace
-    (?P<trailing_modifier>              # optional trailing modifier
-        (?<!\\)\{[^{}]*\}
-    )?                                  # optional
-    \s*                                 # optional whitespace
-    (?P<comment>                        # optional comment
-        (?<!\\)!.*                      # starts with unescaped !
-    )?$
+    (?P<tag>.+?):\s*             # tag and separator
+    (?P<value>.*?)               # value: match anything (non-greedy)
+    (?:\s                        # optional trailing modifier
+        (?P<trailing_modifier>
+            (?<!\\)\{[^{}]*\}    # match unescaped {...}
+        )
+    )?
+    (?:\s
+        (?P<comment>            # optional comment
+            (?<!\\)![^\n]*      # match unescaped ! followed by any characters
+        )
+    )?
+    \s*$                        # optional trailing whitespace
     """,
     re.VERBOSE,
 )
-
 
 def parse_tag_line(line: str) -> tuple[str, str | None, str | None, str | None]:
     """

--- a/tests/test_obo_reading.py
+++ b/tests/test_obo_reading.py
@@ -142,3 +142,12 @@ def test_presence_of_obsolete_nodes() -> None:
     assert "BTO:0000311" in nodes
     node = nodes["BTO:0000311"]
     assert node["is_obsolete"] == "true"
+
+
+def test_curly_braces_in_synonym() -> None:
+    """Test that we can handle curly braces inside synonyms"""
+    line = "synonym: \"10*3.{copies}/mL\" EXACT [] {http://purl.obolibrary.org/something=\"AB\"}"
+    tag, value, trailing_modifier, comment = parse_tag_line(line)
+    assert tag == "synonym"
+    assert value == "\"10*3.{copies}/mL\" EXACT []"
+    assert trailing_modifier

--- a/tests/test_obo_reading.py
+++ b/tests/test_obo_reading.py
@@ -146,8 +146,8 @@ def test_presence_of_obsolete_nodes() -> None:
 
 def test_curly_braces_in_synonym() -> None:
     """Test that we can handle curly braces inside synonyms"""
-    line = "synonym: \"10*3.{copies}/mL\" EXACT [] {http://purl.obolibrary.org/something=\"AB\"}"
+    line = 'synonym: "10*3.{copies}/mL" EXACT [] {http://purl.obolibrary.org/something="AB"}'
     tag, value, trailing_modifier, comment = parse_tag_line(line)
     assert tag == "synonym"
-    assert value == "\"10*3.{copies}/mL\" EXACT []"
+    assert value == '"10*3.{copies}/mL" EXACT []'
     assert trailing_modifier

--- a/tests/test_obo_reading.py
+++ b/tests/test_obo_reading.py
@@ -125,6 +125,15 @@ def test_parse_tag_line_backslashed_exclamation() -> None:
     assert value == r"not a real example \!"
 
 
+def test_parse_tag_line_curly_braces() -> None:
+    """Test that we can handle curly braces inside tag lines"""
+    line = 'synonym: "10*3.{copies}/mL" EXACT [] {http://purl.obolibrary.org/something="AB"}'
+    tag, value, trailing_modifier, comment = parse_tag_line(line)
+    assert tag == "synonym"
+    assert value == '"10*3.{copies}/mL" EXACT []'
+    assert trailing_modifier
+
+
 def test_ignore_obsolete_nodes() -> None:
     """Quick verification that the change doesn't break anything"""
     path = os.path.join(directory, "data", "brenda-subset.obo")
@@ -142,12 +151,3 @@ def test_presence_of_obsolete_nodes() -> None:
     assert "BTO:0000311" in nodes
     node = nodes["BTO:0000311"]
     assert node["is_obsolete"] == "true"
-
-
-def test_curly_braces_in_synonym() -> None:
-    """Test that we can handle curly braces inside synonyms"""
-    line = 'synonym: "10*3.{copies}/mL" EXACT [] {http://purl.obolibrary.org/something="AB"}'
-    tag, value, trailing_modifier, comment = parse_tag_line(line)
-    assert tag == "synonym"
-    assert value == '"10*3.{copies}/mL" EXACT []'
-    assert trailing_modifier


### PR DESCRIPTION
This PR updates the `tag_line_pattern` regexp to resolve an issue where `{` and `}` characters appearing in synonyms caused the synonym line to be cropped. The updated regexp handles these and also makes the regexp pattern definition easier to audit by breaking it up into multiple lines with comments.