### PR TITLE
Propagate trailing modifiers and comments into graph (without breaking anything)

### DIFF
--- a/obonet/read.py
+++ b/obonet/read.py
@@ -149,14 +149,19 @@ def parse_stanza(lines: list[str], tag_singularity: dict[str, bool]) -> dict[str
     Returns a dictionary representation of a stanza.
     """
     stanza: dict[str, Any] = {}
+    modifiers: dict[str, Any] = {}
     for line in lines:
         if line.startswith("!"):
             continue
         tag, value, trailing_modifier, comment = parse_tag_line(line)
+        mod = {"trailing_modifier": trailing_modifier, "comment": comment}
         if tag_singularity.get(tag, False):
             stanza[tag] = value
+            modifiers[tag] = mod
         else:
             stanza.setdefault(tag, []).append(value)
+            modifiers.setdefault(tag, []).append(mod)
+    stanza["_tag_modifiers"] = modifiers
     return stanza
 
 

--- a/obonet/read.py
+++ b/obonet/read.py
@@ -149,19 +149,22 @@ def parse_stanza(lines: list[str], tag_singularity: dict[str, bool]) -> dict[str
     Returns a dictionary representation of a stanza.
     """
     stanza: dict[str, Any] = {}
-    modifiers: dict[str, Any] = {}
+    trailing_modifiers: dict[str, Any] = {}
+    comments: dict[str, Any] = {}
     for line in lines:
         if line.startswith("!"):
             continue
         tag, value, trailing_modifier, comment = parse_tag_line(line)
-        mod = {"trailing_modifier": trailing_modifier, "comment": comment}
         if tag_singularity.get(tag, False):
             stanza[tag] = value
-            modifiers[tag] = mod
+            trailing_modifiers[tag] = trailing_modifier
+            comments[tag] = comment
         else:
             stanza.setdefault(tag, []).append(value)
-            modifiers.setdefault(tag, []).append(mod)
-    stanza["_tag_modifiers"] = modifiers
+            trailing_modifiers.setdefault(tag, []).append(trailing_modifier)
+            comments.setdefault(tag, []).append(comment)
+    stanza["_trailing_modifiers"] = trailing_modifiers
+    stanza["_comments"] = comments
     return stanza
 
 

--- a/obonet/read.py
+++ b/obonet/read.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import itertools
 import logging
 import re
-from typing import Any, Iterator
+from typing import Any, Iterator, NamedTuple
 
 import networkx
 
@@ -124,10 +124,22 @@ tag_line_pattern = re.compile(
 )
 
 
-def parse_tag_line(line: str) -> tuple[str, str | None, str | None, str | None]:
+class TagLine(NamedTuple):
+    """
+    Parsed components of a single OBO tag line.
+    trailing_modifier and comment are None when absent from the line.
+    """
+
+    tag: str
+    value: str | None
+    trailing_modifier: str | None
+    comment: str | None
+
+
+def parse_tag_line(line: str) -> TagLine:
     """
     Take a line representing a single tag-value pair and parse
-    the line into (tag, value, trailing_modifier, comment).
+    the line into a TagLine(tag, value, trailing_modifier, comment).
     """
     match = re.match(tag_line_pattern, line)
     if match is None:
@@ -141,7 +153,7 @@ def parse_tag_line(line: str) -> tuple[str, str | None, str | None, str | None]:
     comment = match.group("comment")
     if comment:
         comment = comment.lstrip("! ")
-    return tag, value, trailing_modifier, comment
+    return TagLine(tag=tag, value=value, trailing_modifier=trailing_modifier, comment=comment)
 
 
 def parse_stanza(lines: list[str], tag_singularity: dict[str, bool]) -> dict[str, Any]:

--- a/obonet/read.py
+++ b/obonet/read.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import itertools
 import logging
 import re
-from typing import Any, Iterator, NamedTuple
+from dataclasses import asdict, dataclass
+from typing import Any, Iterator
 
 import networkx
 
@@ -13,7 +14,10 @@ logger = logging.getLogger(__name__)
 
 
 def read_obo(
-    path_or_file: PathType, ignore_obsolete: bool = True, encoding: str | None = "utf-8"
+    path_or_file: PathType,
+    ignore_obsolete: bool = True,
+    encoding: str | None = "utf-8",
+    include_clauses: bool = False,
 ) -> networkx.MultiDiGraph[str]:
     """
     Return a networkx.MultiDiGraph of the ontology serialized by the
@@ -33,9 +37,13 @@ def read_obo(
     encoding : str or None
         The character set encoding to use for path_or_file when path_or_file
         is a path/URL. Set to None for platform-dependent locale default.
+    include_clauses : boolean
+        When true, include full parsed OBO clauses under the "_clauses" key.
     """
     with open_read_file(path_or_file, encoding=encoding) as obo_file:
-        typedefs, terms, instances, header = get_sections(obo_file)
+        typedefs, terms, instances, header = get_sections(
+            obo_file, include_clauses=include_clauses
+        )
 
     if "ontology" in header:
         header["name"] = header.get("ontology")
@@ -69,6 +77,7 @@ def read_obo(
 
 def get_sections(
     lines: Iterator[str],
+    include_clauses: bool = False,
 ) -> tuple[
     list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]], dict[str, Any]
 ]:
@@ -86,17 +95,25 @@ def get_sections(
             continue
         stanza_type_line, *stanza_lines = stanza_lines_iter
         if stanza_type_line.startswith("[Typedef]"):
-            typedef = parse_stanza(stanza_lines, typedef_tag_singularity)
+            typedef = parse_stanza(
+                stanza_lines, typedef_tag_singularity, include_clauses=include_clauses
+            )
             typedefs.append(typedef)
         elif stanza_type_line.startswith("[Term]"):
-            term = parse_stanza(stanza_lines, term_tag_singularity)
+            term = parse_stanza(
+                stanza_lines, term_tag_singularity, include_clauses=include_clauses
+            )
             terms.append(term)
         elif stanza_type_line.startswith("[Instance]"):
-            instance = parse_stanza(stanza_lines, instance_tag_singularity)
+            instance = parse_stanza(
+                stanza_lines, instance_tag_singularity, include_clauses=include_clauses
+            )
             instances.append(instance)
         else:
             stanza_lines = [stanza_type_line] + stanza_lines
-            header = parse_stanza(stanza_lines, header_tag_singularity)
+            header = parse_stanza(
+                stanza_lines, header_tag_singularity, include_clauses=include_clauses
+            )
     if header is None:
         logger.warning("got no header information")
         header = {}
@@ -124,7 +141,8 @@ tag_line_pattern = re.compile(
 )
 
 
-class TagLine(NamedTuple):
+@dataclass(frozen=True)
+class TagLine:
     """
     Parsed components of a single OBO tag line.
     trailing_modifier and comment are None when absent from the line.
@@ -156,27 +174,28 @@ def parse_tag_line(line: str) -> TagLine:
     return TagLine(tag=tag, value=value, trailing_modifier=trailing_modifier, comment=comment)
 
 
-def parse_stanza(lines: list[str], tag_singularity: dict[str, bool]) -> dict[str, Any]:
+def parse_stanza(
+    lines: list[str],
+    tag_singularity: dict[str, bool],
+    include_clauses: bool = False,
+) -> dict[str, Any]:
     """
     Returns a dictionary representation of a stanza.
     """
     stanza: dict[str, Any] = {}
-    trailing_modifiers: dict[str, Any] = {}
-    comments: dict[str, Any] = {}
+    clauses: list[dict[str, str | None]] = []
     for line in lines:
         if line.startswith("!"):
             continue
-        tag, value, trailing_modifier, comment = parse_tag_line(line)
-        if tag_singularity.get(tag, False):
-            stanza[tag] = value
-            trailing_modifiers[tag] = trailing_modifier
-            comments[tag] = comment
+        tag_line = parse_tag_line(line)
+        if include_clauses:
+            clauses.append(asdict(tag_line))
+        if tag_singularity.get(tag_line.tag, False):
+            stanza[tag_line.tag] = tag_line.value
         else:
-            stanza.setdefault(tag, []).append(value)
-            trailing_modifiers.setdefault(tag, []).append(trailing_modifier)
-            comments.setdefault(tag, []).append(comment)
-    stanza["_trailing_modifiers"] = trailing_modifiers
-    stanza["_comments"] = comments
+            stanza.setdefault(tag_line.tag, []).append(tag_line.value)
+    if include_clauses:
+        stanza["_clauses"] = clauses
     return stanza
 
 

--- a/obonet/read.py
+++ b/obonet/read.py
@@ -171,7 +171,12 @@ def parse_tag_line(line: str) -> TagLine:
     comment = match.group("comment")
     if comment:
         comment = comment.lstrip("! ")
-    return TagLine(tag=tag, value=value, trailing_modifier=trailing_modifier, comment=comment)
+    return TagLine(
+        tag=tag,
+        value=value,
+        trailing_modifier=trailing_modifier,
+        comment=comment,
+    )
 
 
 def parse_stanza(

--- a/tests/test_obo_reading.py
+++ b/tests/test_obo_reading.py
@@ -187,10 +187,24 @@ def test_parse_stanza_with_clauses() -> None:
 def test_read_obo_with_clauses() -> None:
     path = os.path.join(directory, "data", "taxrank.obo")
     taxrank = obonet.read_obo(path)
+    assert "_clauses" not in taxrank.graph
+    assert "_clauses" not in taxrank.graph["typedefs"][0]
     node = get_node(taxrank, "TAXRANK:0000001")
     assert "_clauses" not in node
 
     taxrank = obonet.read_obo(path, include_clauses=True)
+    assert taxrank.graph["_clauses"][0] == {
+        "tag": "format-version",
+        "value": "1.2",
+        "trailing_modifier": None,
+        "comment": None,
+    }
+    assert taxrank.graph["typedefs"][0]["_clauses"][0] == {
+        "tag": "id",
+        "value": "TAXRANK:1000000",
+        "trailing_modifier": None,
+        "comment": None,
+    }
     node = get_node(taxrank, "TAXRANK:0000001")
     clauses = node["_clauses"]
     assert clauses[0] == {

--- a/tests/test_obo_reading.py
+++ b/tests/test_obo_reading.py
@@ -134,17 +134,34 @@ def test_parse_tag_line_curly_braces() -> None:
     assert trailing_modifier
 
 
-def test_trailing_modifiers() -> None:
-    """The _tag_modifiers should be present and line up with values."""
+def test_trailing_modifiers_and_comments() -> None:
+    """The _trailing_modifiers and _comments should line up with values,
+    covering all four combinations of modifier/comment being present."""
     lines = [
-        'xref: DOID:14250 {source="MONDO:equivalentTo"}',
-        "xref: GARD:0010247",
+        'xref: DOID:14250 {source="MONDO:equivalentTo"} ! Down syndrome',
+        'xref: GARD:0010247 {source="MONDO:equivalentTo"}',
+        "xref: MESH:D004314 ! Down Syndrome",
+        "xref: NCIT:C2993",
     ]
     stanza = parse_stanza(lines, term_tag_singularity)
-    assert stanza["xref"] == ["DOID:14250", "GARD:0010247"]
-    modifiers = stanza["_tag_modifiers"]["xref"]
-    assert modifiers[0]["trailing_modifier"] == 'source="MONDO:equivalentTo"'
-    assert modifiers[1]["trailing_modifier"] is None
+    assert stanza["xref"] == [
+        "DOID:14250",
+        "GARD:0010247",
+        "MESH:D004314",
+        "NCIT:C2993",
+    ]
+    assert stanza["_trailing_modifiers"]["xref"] == [
+        'source="MONDO:equivalentTo"',
+        'source="MONDO:equivalentTo"',
+        None,
+        None,
+    ]
+    assert stanza["_comments"]["xref"] == [
+        "Down syndrome",
+        None,
+        "Down Syndrome",
+        None,
+    ]
 
 
 def test_ignore_obsolete_nodes() -> None:

--- a/tests/test_obo_reading.py
+++ b/tests/test_obo_reading.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+from typing import Any
 
 import pytest
 
@@ -9,17 +10,24 @@ from obonet.read import parse_stanza, parse_tag_line, term_tag_singularity
 directory = os.path.dirname(os.path.abspath(__file__))
 
 
+def get_node(graph: Any, node: str) -> Any:
+    if hasattr(graph, "node"):
+        # NetworkX 1.x
+        return graph.node[node]
+    # NetworkX 2.x
+    return graph.nodes[node]
+
+
 def test_read_taxrank_file() -> None:
     """
     Test reading the taxrank ontology OBO file.
     """
-    pytest.importorskip("networkx", minversion="2.0")
     path = os.path.join(directory, "data", "taxrank.obo")
     with open(path) as read_file:
         taxrank = obonet.read_obo(read_file)
     assert len(taxrank) == 61
-    assert taxrank.nodes["TAXRANK:0000001"]["name"] == "phylum"
-    assert "NCBITaxon:kingdom" in taxrank.nodes["TAXRANK:0000017"]["xref"]
+    assert get_node(taxrank, "TAXRANK:0000001")["name"] == "phylum"
+    assert "NCBITaxon:kingdom" in get_node(taxrank, "TAXRANK:0000017")["xref"]
 
 
 @pytest.mark.parametrize("extension", ["", ".gz", ".bz2", ".xz"])
@@ -179,10 +187,12 @@ def test_parse_stanza_with_clauses() -> None:
 def test_read_obo_with_clauses() -> None:
     path = os.path.join(directory, "data", "taxrank.obo")
     taxrank = obonet.read_obo(path)
-    assert "_clauses" not in taxrank.nodes["TAXRANK:0000001"]
+    node = get_node(taxrank, "TAXRANK:0000001")
+    assert "_clauses" not in node
 
     taxrank = obonet.read_obo(path, include_clauses=True)
-    clauses = taxrank.nodes["TAXRANK:0000001"]["_clauses"]
+    node = get_node(taxrank, "TAXRANK:0000001")
+    clauses = node["_clauses"]
     assert clauses[0] == {
         "tag": "id",
         "value": "TAXRANK:0000001",

--- a/tests/test_obo_reading.py
+++ b/tests/test_obo_reading.py
@@ -4,7 +4,7 @@ import pathlib
 import pytest
 
 import obonet
-from obonet.read import parse_tag_line
+from obonet.read import parse_stanza, parse_tag_line, term_tag_singularity
 
 directory = os.path.dirname(os.path.abspath(__file__))
 
@@ -132,6 +132,19 @@ def test_parse_tag_line_curly_braces() -> None:
     assert tag == "synonym"
     assert value == '"10*3.{copies}/mL" EXACT []'
     assert trailing_modifier
+
+
+def test_trailing_modifiers() -> None:
+    """The _tag_modifiers should be present and line up with values."""
+    lines = [
+        'xref: DOID:14250 {source="MONDO:equivalentTo"}',
+        "xref: GARD:0010247",
+    ]
+    stanza = parse_stanza(lines, term_tag_singularity)
+    assert stanza["xref"] == ["DOID:14250", "GARD:0010247"]
+    modifiers = stanza["_tag_modifiers"]["xref"]
+    assert modifiers[0]["trailing_modifier"] == 'source="MONDO:equivalentTo"'
+    assert modifiers[1]["trailing_modifier"] is None
 
 
 def test_ignore_obsolete_nodes() -> None:

--- a/tests/test_obo_reading.py
+++ b/tests/test_obo_reading.py
@@ -75,93 +75,126 @@ def test_read_obo(ontology: str) -> None:
 
 def test_parse_tag_line_newline_agnostic() -> None:
     for line in ["saved-by: vw", "saved-by: vw\n"]:
-        tag, value, trailing_modifier, comment = parse_tag_line(line)
-        assert tag == "saved-by"
-        assert value == "vw"
-        assert trailing_modifier is None
-        assert comment is None
+        tag_line = parse_tag_line(line)
+        assert tag_line.tag == "saved-by"
+        assert tag_line.value == "vw"
+        assert tag_line.trailing_modifier is None
+        assert tag_line.comment is None
 
 
 def test_parse_tag_line_with_tag_and_value() -> None:
     line = 'synonym: "ovarian ring canal" NARROW []\n'
-    tag, value, trailing_modifier, comment = parse_tag_line(line)
-    assert tag == "synonym"
-    assert value == '"ovarian ring canal" NARROW []'
-    assert trailing_modifier is None
-    assert comment is None
+    tag_line = parse_tag_line(line)
+    assert tag_line.tag == "synonym"
+    assert tag_line.value == '"ovarian ring canal" NARROW []'
+    assert tag_line.trailing_modifier is None
+    assert tag_line.comment is None
 
 
 def test_parse_tag_line_with_tag_value_and_comment() -> None:
     line = "is_a: GO:0005102 ! receptor binding\n"
-    tag, value, trailing_modifier, comment = parse_tag_line(line)
-    assert tag == "is_a"
-    assert value == "GO:0005102"
-    assert trailing_modifier is None
-    assert comment == "receptor binding"
+    tag_line = parse_tag_line(line)
+    assert tag_line.tag == "is_a"
+    assert tag_line.value == "GO:0005102"
+    assert tag_line.trailing_modifier is None
+    assert tag_line.comment == "receptor binding"
 
 
 def test_parse_tag_line_with_tag_value_and_trailing_modifier() -> None:
     line = 'xref: UMLS:C0226369 {source="ncithesaurus:Obturator_Artery"}\n'
-    tag, value, trailing_modifier, comment = parse_tag_line(line)
-    assert tag == "xref"
-    assert value == "UMLS:C0226369"
-    assert trailing_modifier == 'source="ncithesaurus:Obturator_Artery"'
-    assert comment is None
+    tag_line = parse_tag_line(line)
+    assert tag_line.tag == "xref"
+    assert tag_line.value == "UMLS:C0226369"
+    assert tag_line.trailing_modifier == 'source="ncithesaurus:Obturator_Artery"'
+    assert tag_line.comment is None
 
 
 def test_parse_tag_line_with_tag_value_trailing_modifier_and_comment() -> None:
     line = 'xref: UMLS:C0022131 {source="ncithesaurus:Islet_of_Langerhans"} ! Islets of Langerhans\n'  # noqa: E501
-    tag, value, trailing_modifier, comment = parse_tag_line(line)
-    assert tag == "xref"
-    assert value == "UMLS:C0022131"
-    assert trailing_modifier == 'source="ncithesaurus:Islet_of_Langerhans"'
-    assert comment == "Islets of Langerhans"
+    tag_line = parse_tag_line(line)
+    assert tag_line.tag == "xref"
+    assert tag_line.value == "UMLS:C0022131"
+    assert tag_line.trailing_modifier == 'source="ncithesaurus:Islet_of_Langerhans"'
+    assert tag_line.comment == "Islets of Langerhans"
 
 
 def test_parse_tag_line_backslashed_exclamation() -> None:
     line = "synonym: not a real example \\!\n"
-    tag, value, trailing_modifier, comment = parse_tag_line(line)
-    assert tag == "synonym"
-    assert value == r"not a real example \!"
+    tag_line = parse_tag_line(line)
+    assert tag_line.tag == "synonym"
+    assert tag_line.value == r"not a real example \!"
 
 
 def test_parse_tag_line_curly_braces() -> None:
     """Test that we can handle curly braces inside tag lines"""
     line = 'synonym: "10*3.{copies}/mL" EXACT [] {http://purl.obolibrary.org/something="AB"}'
-    tag, value, trailing_modifier, comment = parse_tag_line(line)
-    assert tag == "synonym"
-    assert value == '"10*3.{copies}/mL" EXACT []'
-    assert trailing_modifier
+    tag_line = parse_tag_line(line)
+    assert tag_line.tag == "synonym"
+    assert tag_line.value == '"10*3.{copies}/mL" EXACT []'
+    assert tag_line.trailing_modifier
 
 
-def test_trailing_modifiers_and_comments() -> None:
-    """The _trailing_modifiers and _comments should line up with values,
-    covering all four combinations of modifier/comment being present."""
+def test_parse_stanza_with_clauses() -> None:
     lines = [
         'xref: DOID:14250 {source="MONDO:equivalentTo"} ! Down syndrome',
         'xref: GARD:0010247 {source="MONDO:equivalentTo"}',
         "xref: MESH:D004314 ! Down Syndrome",
         "xref: NCIT:C2993",
     ]
-    stanza = parse_stanza(lines, term_tag_singularity)
+    stanza = parse_stanza(lines, term_tag_singularity, include_clauses=True)
     assert stanza["xref"] == [
         "DOID:14250",
         "GARD:0010247",
         "MESH:D004314",
         "NCIT:C2993",
     ]
-    assert stanza["_trailing_modifiers"]["xref"] == [
-        'source="MONDO:equivalentTo"',
-        'source="MONDO:equivalentTo"',
-        None,
-        None,
+    assert stanza["_clauses"] == [
+        {
+            "tag": "xref",
+            "value": "DOID:14250",
+            "trailing_modifier": 'source="MONDO:equivalentTo"',
+            "comment": "Down syndrome",
+        },
+        {
+            "tag": "xref",
+            "value": "GARD:0010247",
+            "trailing_modifier": 'source="MONDO:equivalentTo"',
+            "comment": None,
+        },
+        {
+            "tag": "xref",
+            "value": "MESH:D004314",
+            "trailing_modifier": None,
+            "comment": "Down Syndrome",
+        },
+        {
+            "tag": "xref",
+            "value": "NCIT:C2993",
+            "trailing_modifier": None,
+            "comment": None,
+        },
     ]
-    assert stanza["_comments"]["xref"] == [
-        "Down syndrome",
-        None,
-        "Down Syndrome",
-        None,
-    ]
+
+
+def test_read_obo_with_clauses() -> None:
+    path = os.path.join(directory, "data", "taxrank.obo")
+    taxrank = obonet.read_obo(path)
+    assert "_clauses" not in taxrank.nodes["TAXRANK:0000001"]
+
+    taxrank = obonet.read_obo(path, include_clauses=True)
+    clauses = taxrank.nodes["TAXRANK:0000001"]["_clauses"]
+    assert clauses[0] == {
+        "tag": "id",
+        "value": "TAXRANK:0000001",
+        "trailing_modifier": None,
+        "comment": None,
+    }
+    assert clauses[1] == {
+        "tag": "name",
+        "value": "phylum",
+        "trailing_modifier": None,
+        "comment": None,
+    }
 
 
 def test_ignore_obsolete_nodes() -> None:


### PR DESCRIPTION
This PR adds a simple extension to `parse_stanza` to retain trailing modifiers and comments associated with OBO lines that are currently dropped and are unavailable in the output networkx graph (only tag and value are retained and propagated). 

A key design decision here is to make this change with **no effect on the representation of existing attributes** that downstream dependencies use. To achieve this, these modifiers and comments are put into two separate attributes called `_trailing_modifiers` and `comments`, respectively. These are structured to be parallel to the values they correspond to.

Example: consider MONDO which has rich annotations associated with `xref`s and other properties, for example:
```
xref: DOID:14250 {source="EFO:0001064", source="MONDO:equivalentTo"}
xref: EFO:0001064 {source="MONDO:equivalentTo", source="MONDO:EFO"}
xref: ICD10CM:Q90 {source="https://orcid.org/0009-0001-6494-4831", source="DOID:14250", source="MONDO:equivalentTo", source="https://orcid.org/0000-0002-5002-8648"}
xref: ICD10WHO:Q90 {source="https://orcid.org/0000-0002-7941-5545", source="MONDO:equivalentTo", 
...
```

Previously, only a flat list of `xref`s was propagated. With this change, we are able to access the modifiers and comments as well:

```python
In [1]: import obonet

In [2]: g = obonet.read_obo('https://purl.obolibrary.org/obo/mondo.obo')

# This is unchanged so won't break downstream usage

In [3]: g.nodes['MONDO:0008608']['xref']
Out[3]:
['DOID:14250',
 'EFO:0001064',
 'ICD10CM:Q90',
 'ICD10WHO:Q90',
 'icd11.foundation:1624623908',
 'ICD9:758.0',
 'MedDRA:10044688',
 'MEDGEN:4385',
 'MESH:D004314',
 'NANDO:2200965',
 'NCIT:C2993',
 'OMIM:190685',
 'Orphanet:870',
 'SCTID:41040004',
 'UMLS:C0013080']

# This is new

In [4]: g.nodes['MONDO:0008608']['_trailing_modifiers']['xref']
Out[4]:
['source="EFO:0001064", source="MONDO:equivalentTo"',
 'source="MONDO:equivalentTo", source="MONDO:EFO"',
 'source="https://orcid.org/0009-0001-6494-4831", source="DOID:14250", source="MONDO:equivalentTo", source="https://orcid.org/0000-0002-5002-8648"',
 'source="https://orcid.org/0000-0002-7941-5545", source="MONDO:equivalentTo", source="https://orcid.org/0000-0001-9439-5346"',
 'source="MONDO:equivalentTo", source="Orphanet:870", source="https://orcid.org/0000-0002-4142-7153"',
 'source="EFO:0001064", source="DOID:14250", source="MONDO:equivalentTo", source="MONDO:i2s"',
 'source="Orphanet:870/e", source="Orphanet:870"',
 'source="MONDO:equivalentTo", source="MONDO:MEDGEN"',
 'source="EFO:0001064", source="Orphanet:870/e", source="DOID:14250", source="MONDO:equivalentTo", source="Orphanet:870"',
 'source="MONDO:NANDO", source="https://orcid.org/0000-0003-0011-764X", source="https://orcid.org/0000-0002-0170-9172"',
 'source="EFO:0001064", source="DOID:14250", source="MONDO:equivalentTo"',
 'source="Orphanet:870/e", source="DOID:14250", source="MONDO:equivalentTo", source="Orphanet:870"',
 'source="OMIM:190685", source="MONDO:equivalentTo"',
 'source="EFO:0001064", source="DOID:14250", source="MONDO:equivalentTo"',
 'source="MEDGEN:4385", source="MONDO:equivalentTo", source="MONDO:MEDGEN"']
```

I think this is a useful feature and necessary to retain some of the metadata that is currently dropped. 

My only concern is that it makes node attributes a bit verbose (e.g., g.nodes['MONDO:0008608'] prints out as much longer) and increases the size of the graph. One potential consideration would be to make this optional, i.e., to add an argument to `read_obo` to control whether these additional fields are propagated